### PR TITLE
Replace all uses of InstallValue

### DIFF
--- a/lib/main.gd
+++ b/lib/main.gd
@@ -138,7 +138,7 @@ DeclareGlobalFunction( "Plot" );
 #!  <Ref Func="JUPVIZFetchIfPresent"/>.  Following those examples will
 #!  help keep your code consistent with existing code and as concise as
 #!  possible.
-DeclareGlobalVariable( "ConvertDataSeriesForTool" );
+#DeclareGlobalVariable( "ConvertDataSeriesForTool" );
 
 #! @Arguments various
 #! @Returns one of two things, documented below
@@ -259,7 +259,7 @@ DeclareGlobalFunction( "PlotGraph" );
 #!  <Ref Func="JUPVIZFetchIfPresent"/>.  Following those examples will
 #!  help keep your code consistent with existing code and as concise as
 #!  possible.
-DeclareGlobalVariable( "ConvertGraphForTool" );
+#DeclareGlobalVariable( "ConvertGraphForTool" );
 
 #! @Description
 #!  The <Package>JupyterViz</Package> Package can display visualizations in
@@ -292,8 +292,7 @@ DeclareGlobalVariable( "ConvertGraphForTool" );
 #!  <Package>JupyterKernel</Package> Package, and even then, all that
 #!  would be produced by this package would be data structures that would,
 #!  if evaluated in a Jupyter notebook, produce visualizations.
-DeclareGlobalVariable( "PlotDisplayMethod" );
-MakeReadWriteGlobal( "PlotDisplayMethod" );
+#DeclareGlobalVariable( "PlotDisplayMethod" );
 
 #! @Description
 #!  This global constant can be assigned to the global variable
@@ -318,7 +317,7 @@ MakeReadWriteGlobal( "PlotDisplayMethod" );
 #!      the cells that created them, so that the required libraries are
 #!      re-fetched from the &GAP; Jupyter kernel.</Item>
 #!  </List>
-DeclareGlobalVariable( "PlotDisplayMethod_Jupyter" );
+#DeclareGlobalVariable( "PlotDisplayMethod_Jupyter" );
 
 #! @Description
 #!  This global constant can be assigned to the global variable
@@ -343,7 +342,7 @@ DeclareGlobalVariable( "PlotDisplayMethod_Jupyter" );
 #!      in the output cell itself, and is re-run upon re-opening the
 #!      notebook.</Item>
 #!  </List>
-DeclareGlobalVariable( "PlotDisplayMethod_JupyterSimple" );
+#DeclareGlobalVariable( "PlotDisplayMethod_JupyterSimple" );
 
 #! @Description
 #!  This global constant can be assigned to the global variable
@@ -366,7 +365,7 @@ DeclareGlobalVariable( "PlotDisplayMethod_JupyterSimple" );
 #!      the cells that created them, so that the required libraries are
 #!      re-fetched from the &GAP; Jupyter kernel.</Item>
 #!  </List>
-DeclareGlobalVariable( "PlotDisplayMethod_HTML" );
+#DeclareGlobalVariable( "PlotDisplayMethod_HTML" );
 
 #! @Section Low-Level Public API
 
@@ -539,7 +538,7 @@ DeclareGlobalFunction( "JUPVIZAbsoluteJavaScriptFilename" );
 #!  from this package's folder.  The existence of this cache means needing
 #!  to go to the filesystem for these files only once per &GAP; session.
 #!  This cache is used by <Ref Func="LoadJavaScriptFile"/>.
-DeclareGlobalVariable( "JUPVIZLoadedJavaScriptCache" );
+#DeclareGlobalVariable( "JUPVIZLoadedJavaScriptCache" );
 
 #! @Arguments filename, dictionary
 #! @Returns a string containing the contents of the given template file, filled in using the given dictionary

--- a/lib/main.gi
+++ b/lib/main.gi
@@ -10,18 +10,18 @@
 
 
 ##  Set the three possible values of PlotDisplayMethod to constants.
-InstallValue( PlotDisplayMethod_Jupyter, "PlotDisplayMethod_Jupyter" );
-InstallValue( PlotDisplayMethod_JupyterSimple, "PlotDisplayMethod_JupyterSimple" );
-InstallValue( PlotDisplayMethod_HTML, "PlotDisplayMethod_HTML" );
+BindGlobal( "PlotDisplayMethod_Jupyter", MakeImmutable( "PlotDisplayMethod_Jupyter" ) ) );
+BindGlobal( "PlotDisplayMethod_JupyterSimple", MakeImmutable( "PlotDisplayMethod_JupyterSimple" ) );
+BindGlobal( "PlotDisplayMethod_HTML", MakeImmutable( "PlotDisplayMethod_HTML" ) );
 
 
 ##  Detect whether the JupyterKernel package is available.
 ##  If it is, set our default display mode to using JupyterRenderable objects.
 ##  Otherwise, we'll use plain HTML.
 if IsBoundGlobal( "JupyterRenderable" ) then
-    InstallValue( PlotDisplayMethod, PlotDisplayMethod_Jupyter );
+    PlotDisplayMethod := PlotDisplayMethod_Jupyter;
 else
-    InstallValue( PlotDisplayMethod, PlotDisplayMethod_HTML );
+    PlotDisplayMethod := PlotDisplayMethod_HTML;
 fi;
 
 
@@ -120,7 +120,7 @@ function ( relativeFilename )
 end );
 
 
-InstallValue( JUPVIZLoadedJavaScriptCache, rec( ) );
+BindGlobal( "JUPVIZLoadedJavaScriptCache", rec( ) );
 InstallGlobalFunction( LoadJavaScriptFile, function ( filename )
     local absolute, result;
     if IsBound( JUPVIZLoadedJavaScriptCache.( filename ) ) then
@@ -384,7 +384,7 @@ function ( record, others, chain, action )
 end );
 
 
-InstallValue( ConvertDataSeriesForTool, rec() );
+BindGlobal( "ConvertDataSeriesForTool", rec() );
 
 
 ConvertDataSeriesForTool.plotly := function ( series )
@@ -659,7 +659,7 @@ InstallGlobalFunction( Plot, function ( args... )
 end );
 
 
-InstallValue( ConvertGraphForTool, rec() );
+BindGlobal( "ConvertGraphForTool", rec() );
 
 
 ConvertGraphForTool.cytoscape := function ( graph )


### PR DESCRIPTION
See https://github.com/gap-system/gap/issues/1637 for some background.

The `DeclareGlobalVariable` calls are left in, commented out, so that
AutoDoc still "sees" them when generating the manual.
