### PR TITLE
Add CI tests, which also try to build the manual

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,65 @@
+name: CI
+
+# Trigger the workflow on push or pull request
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
+# the `concurrency` settings ensure that not too many CI jobs run in parallel
+concurrency:
+  # group by workflow and ref; the last slightly strange component ensures that for pull
+  # requests, we limit to 1 concurrent job, but for the master branch we don't
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.ref != 'refs/heads/master' || github.run_number }}
+  # Cancel intermediate builds, but only if it is a pull request build.
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+
+jobs:
+  # The CI test job
+  test:
+    name: ${{ matrix.gap-branch }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        gap-branch:
+          - master
+          - stable-4.11
+          - stable-4.10
+          - stable-4.9
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: 'Install initial dependencies'
+        run: |
+          sudo apt-get install libzmq3-dev
+      - uses: gap-actions/setup-gap@v2
+        with:
+          # WORKAROUND: we have both zeromqinterface and ZeroMQInterface
+          # in the list because GAP_PKGS_TO_BUILD is dumb and tries to
+          # match packages based on directory names, and here the case
+          # changed ...
+          GAP_PKGS_TO_BUILD: "io profiling crypting json uuid zeromqinterface ZeroMQInterface"
+          GAPBRANCH: ${{ matrix.gap-branch }}
+      - uses: gap-actions/build-pkg@v1
+      - uses: gap-actions/run-pkg-tests@v2
+      - uses: gap-actions/process-coverage@v2
+      - uses: codecov/codecov-action@v2
+
+  # Test building the documentation
+  manual:
+    name: Build manuals
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: gap-actions/setup-gap@v2
+      - uses: gap-actions/build-pkg-docs@v1
+        with:
+          use-latex: 'true'
+      - name: 'Upload documentation'
+        uses: actions/upload-artifact@v2
+        with:
+          name: manual
+          path: ./doc/manual.pdf

--- a/lib/main.gi
+++ b/lib/main.gi
@@ -10,7 +10,7 @@
 
 
 ##  Set the three possible values of PlotDisplayMethod to constants.
-BindGlobal( "PlotDisplayMethod_Jupyter", MakeImmutable( "PlotDisplayMethod_Jupyter" ) ) );
+BindGlobal( "PlotDisplayMethod_Jupyter", MakeImmutable( "PlotDisplayMethod_Jupyter" ) );
 BindGlobal( "PlotDisplayMethod_JupyterSimple", MakeImmutable( "PlotDisplayMethod_JupyterSimple" ) );
 BindGlobal( "PlotDisplayMethod_HTML", MakeImmutable( "PlotDisplayMethod_HTML" ) );
 


### PR DESCRIPTION
This way future breakages in makedoc.g or the test suite will be caught early.

UPDATE: contains and hence closes #19