### PR TITLE
Fix a syntax error

### DIFF
--- a/lib/main.gi
+++ b/lib/main.gi
@@ -10,7 +10,7 @@
 
 
 ##  Set the three possible values of PlotDisplayMethod to constants.
-BindGlobal( "PlotDisplayMethod_Jupyter", MakeImmutable( "PlotDisplayMethod_Jupyter" ) ) );
+BindGlobal( "PlotDisplayMethod_Jupyter", MakeImmutable( "PlotDisplayMethod_Jupyter" ) );
 BindGlobal( "PlotDisplayMethod_JupyterSimple", MakeImmutable( "PlotDisplayMethod_JupyterSimple" ) );
 BindGlobal( "PlotDisplayMethod_HTML", MakeImmutable( "PlotDisplayMethod_HTML" ) );
 


### PR DESCRIPTION
The current release is broken and won't even pass its own test suite because of this typo.

I would strongly suggest to merge both this PR and also https://github.com/nathancarter/jupyterviz/pull/18, then wait till the test suite there passes. Then before any release, you can check the state of the CI test suite run here on GitHub to see if it still passes there (of course running the tests manually locally in addition is also a good idea, but all kinds of issue can "cover up" problems locally)